### PR TITLE
All reading and writing now uses UTF-8.

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,13 @@ Haddock documentation.  There are two good ways to accomplish this:
 
     It may not be pretty, but it works!
 
+## File encodings
+
+For now, `diagrams-haddock` assumes that all `.hs` and `.lhs` files
+are encoded using UTF-8.  If you would like to use it with source
+files stored using some other encoding, feel free to [file a feature
+request](https://github.com/diagrams/diagrams-haddock/issues).
+
 ## The diagrams-haddock library
 
 For most use cases, simply using the `diagrams-haddock` executable

--- a/diagrams-haddock.cabal
+++ b/diagrams-haddock.cabal
@@ -44,7 +44,8 @@ library
                        vector-space >= 0.8 && < 0.9,
                        lens >= 3.8 && < 3.9,
                        cpphs >= 1.15,
-                       cautious-file >= 1.0 && < 1.1
+                       cautious-file >= 1.0 && < 1.1,
+                       text >= 0.11 && < 0.12
   hs-source-dirs:      src
   other-extensions:    TemplateHaskell
   default-language:    Haskell2010

--- a/src/Diagrams/Haddock.hs
+++ b/src/Diagrams/Haddock.hs
@@ -63,9 +63,6 @@ module Diagrams.Haddock
 
     ) where
 
-import           Prelude                         hiding (writeFile)
-import qualified System.IO.Cautious              as Cautiously
-
 import           Control.Applicative             hiding (many, (<|>))
 import           Control.Arrow                   (first, (&&&), (***))
 import           Control.Lens                    hiding ((<.>))
@@ -81,6 +78,8 @@ import           Data.List.Split                 (dropBlanks, dropDelims, split,
 import qualified Data.Map                        as M
 import           Data.Maybe                      (catMaybes, mapMaybe)
 import qualified Data.Set                        as S
+import qualified Data.Text.Lazy                  as T
+import qualified Data.Text.Lazy.Encoding         as T
 import           Data.VectorSpace                (zeroV)
 import           Language.Haskell.Exts.Annotated hiding (loc)
 import qualified Language.Haskell.Exts.Annotated as HSE
@@ -89,6 +88,8 @@ import           System.Directory                (copyFile,
                                                   createDirectoryIfMissing,
                                                   doesFileExist)
 import           System.FilePath                 ((<.>), (</>))
+import qualified System.IO                       as IO
+import qualified System.IO.Cautious              as Cautiously
 import qualified System.IO.Strict                as Strict
 import           Text.Blaze.Svg.Renderer.Utf8    (renderSvg)
 import           Text.Parsec
@@ -456,7 +457,10 @@ processHaddockDiagrams' opts cacheDir outputDir file = do
   case e of
     False -> return ["Error: " ++ file ++ " not found."]
     True  -> do
-      src <- Strict.readFile file
+      -- always assume UTF-8, to make our lives simpler!
+      h <- IO.openFile file IO.ReadMode
+      IO.hSetEncoding h IO.utf8
+      src <- Strict.hGetContents h
       r <- go src
       case r of
         (Nothing, msgs) -> return msgs
@@ -467,7 +471,12 @@ processHaddockDiagrams' opts cacheDir outputDir file = do
             Right urls -> do
               (urls', changed) <- compileDiagrams cacheDir outputDir c urls
               let src' = displayDiagramURLs urls'
-              when changed $ Cautiously.writeFile file src'
+
+              -- See https://github.com/diagrams/diagrams-haddock/issues/8:
+              -- Cautiously.writeFile truncates chars to 8 bits.  So
+              -- we do the encoding to UTF-8 ourselves and then call
+              -- writeFileL.
+              when changed $ Cautiously.writeFileL file (T.encodeUtf8 . T.pack $ src')
               return msgs
   where
     go src =


### PR DESCRIPTION
- Explicitly set encoding of input files to UTF-8.
  - When writing output, do UTF-8 encoding ourselves and then call
    System.IO.Cautiously.writeFileL, which takes a ByteString.  We
    can't use Cautiously.writeFile since it truncates all code points
    to 8 bits.
  
  Fixes #8.
