### PR TITLE
Update version bounds for diagrams-svg

### DIFF
--- a/diagrams-haddock.cabal
+++ b/diagrams-haddock.cabal
@@ -48,7 +48,7 @@ library
                        svg-builder >= 0.1 && < 0.2,
                        diagrams-builder >= 0.5 && < 0.8,
                        diagrams-lib >= 0.6 && < 1.4,
-                       diagrams-svg >= 0.8.0.1 && < 1.5,
+                       diagrams-svg >= 1.4 && < 1.5,
                        lens >= 3.8 && < 4.14,
                        linear >= 1.10 && < 1.21,
                        cpphs >= 1.15,


### PR DESCRIPTION
Since in https://github.com/diagrams/diagrams-haddock/commit/e72b3540d274a6c3bcb1063d1e491c745bed0238 we now use `Graphics.Svg.Core.renderBS` (which takes type `Graphics.Svg.Core.Element`), the type that the old diagrams-svg returned (`Svg ()`) will not work. So this code will not compile with the old diagrams-svg.