### PR TITLE
Non-hacky CPP support

### DIFF
--- a/src/Diagrams/Haddock.hs
+++ b/src/Diagrams/Haddock.hs
@@ -578,10 +578,11 @@ processHaddockDiagrams' opts quiet dataURIs cacheDir outputDir file = do
               when changed $ Cautiously.writeFileL file (T.encodeUtf8 . T.pack $ src')
               return (msgs ++ msgs2)
   where
-    go src =
-      case runCE (parseCodeBlocks file src) of
-        r@(Nothing, msgs) -> if any (("Parse error: #" `elem`) . lines) msgs
-                             then runCpp src >>= return . runCE . parseCodeBlocks file
-                             else return r
-        r -> return r
+    go src | needsCPP src = runCpp src >>= return . runCE . parseCodeBlocks file
+           | otherwise    = runCE (parseCodeBlocks file src)
+
+    needsCPP src = case readExtensions src of
+                     Just (_, es) | find (== EnableExtension CPP) es -> True
+                     _                                               -> False
+
     runCpp s = runCpphs opts file s

--- a/src/Diagrams/Haddock.hs
+++ b/src/Diagrams/Haddock.hs
@@ -579,10 +579,10 @@ processHaddockDiagrams' opts quiet dataURIs cacheDir outputDir file = do
               return (msgs ++ msgs2)
   where
     go src | needsCPP src = runCpp src >>= return . runCE . parseCodeBlocks file
-           | otherwise    = runCE (parseCodeBlocks file src)
+           | otherwise    = return $ runCE (parseCodeBlocks file src)
 
     needsCPP src = case readExtensions src of
-                     Just (_, es) | find (== EnableExtension CPP) es -> True
-                     _                                               -> False
+                     Just (_, es) | EnableExtension CPP `elem` es -> True
+                     _                                            -> False
 
     runCpp s = runCpphs opts file s


### PR DESCRIPTION
Instead of looking for a specific parse error message, we look for the CPP language extension using `readExtensions`.  We might want to consider finding CPP enabled in the cabal file as well.